### PR TITLE
[codex] Clean main branch references

### DIFF
--- a/.github/workflows/check.yml
+++ b/.github/workflows/check.yml
@@ -2,9 +2,9 @@ name: PHP checks
 
 on:
   push:
-    branches: [master, main]
+    branches: [main]
   pull_request:
-    branches: [master, main]
+    branches: [main]
 
 jobs:
   syntax:


### PR DESCRIPTION
## Summary
- Removed temporary master workflow support after the default branch rename.
- Finishes the post-rename cleanup for the repository.

## Validation
- Local: PHP is not installed here; GitHub Actions will run sh scripts/check.sh with PHP 8.4.
