### PR TITLE
[codex] polish php fundamentals archive readiness

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,30 +2,29 @@
 
 # PHP Web Fundamentals
 
-Standalone PHP, HTML, CSS, JavaScript, and SQL files organized by topic and runnable with the PHP CLI or the built-in PHP server.
+Learning reference with standalone PHP, HTML, CSS, JavaScript, and SQL exercises organized by topic and runnable with the PHP CLI or the built-in PHP server.
 
-[![PHP checks](https://img.shields.io/github/actions/workflow/status/itkrivoshei/php-web-fundamentals/check.yml?branch=main&style=for-the-badge&label=php%20checks&logo=githubactions&logoColor=white)](https://github.com/itkrivoshei/php-web-fundamentals/actions/workflows/check.yml)
-[![CodeQL](https://img.shields.io/github/actions/workflow/status/itkrivoshei/php-web-fundamentals/codeql.yml?branch=main&style=for-the-badge&label=codeql&logo=github&logoColor=white)](https://github.com/itkrivoshei/php-web-fundamentals/actions/workflows/codeql.yml)
-[![PHP](https://img.shields.io/badge/PHP-CLI%20%2F%20web-777bb4?style=for-the-badge&logo=php&logoColor=white)](Day01)
-[![JavaScript](https://img.shields.io/badge/JavaScript-browser-f7df1e?style=for-the-badge&logo=javascript&logoColor=000)](Day09)
-[![License](https://img.shields.io/github/license/itkrivoshei/php-web-fundamentals?style=for-the-badge)](LICENSE)
+[![PHP checks](https://img.shields.io/github/actions/workflow/status/itkrivoshei/php-web-fundamentals/check.yml?branch=main&style=for-the-badge&label=php%20checks&logo=githubactions&logoColor=white&labelColor=0f172a)](https://github.com/itkrivoshei/php-web-fundamentals/actions/workflows/check.yml)
+[![CodeQL](https://img.shields.io/github/actions/workflow/status/itkrivoshei/php-web-fundamentals/codeql.yml?branch=main&style=for-the-badge&label=codeql&logo=github&logoColor=white&labelColor=0f172a)](https://github.com/itkrivoshei/php-web-fundamentals/actions/workflows/codeql.yml)
+[![PHP](https://img.shields.io/badge/PHP-CLI%20%2F%20web-777bb4?style=for-the-badge&logo=php&logoColor=white&labelColor=0f172a)](Day01)
+[![JavaScript](https://img.shields.io/badge/JavaScript-browser-f7df1e?style=for-the-badge&logo=javascript&logoColor=000&labelColor=0f172a)](Day09)
+[![SQL](https://img.shields.io/badge/SQL-query%20files-336791?style=for-the-badge&logo=postgresql&logoColor=white&labelColor=0f172a)](Day05)
+[![License](https://img.shields.io/github/license/itkrivoshei/php-web-fundamentals?style=for-the-badge&labelColor=0f172a)](LICENSE)
 
 </div>
 
-> Maintenance status: archived learning reference. This repository is kept public as a record of older web fundamentals work, but it is not part of the active DevOps portfolio.
-
 ## Contents
 
-| Folder | Focus |
-| --- | --- |
-| `Day00` | HTML/CSS layouts, responsive pages, browser JavaScript |
-| `Day01` | PHP CLI scripts, strings, arrays, parameters |
-| `Day02` | Dates, time parsing, text processing |
-| `Day03` | GET parameters, cookies, raw output, protected pages |
-| `Day04` | Account creation, auth flow, login/logout, chat pages |
-| `Day05` | SQL query files |
-| `Day07` | Object-oriented PHP classes |
-| `Day09` | Browser JavaScript interactions |
+| Folder           | Focus                                                  |
+| ---------------- | ------------------------------------------------------ |
+| [`Day00`](Day00) | HTML/CSS layouts, responsive pages, browser JavaScript |
+| [`Day01`](Day01) | PHP CLI scripts, strings, arrays, parameters           |
+| [`Day02`](Day02) | Dates, time parsing, text processing                   |
+| [`Day03`](Day03) | GET parameters, cookies, raw output, protected pages   |
+| [`Day04`](Day04) | Account creation, auth flow, login/logout, chat pages  |
+| [`Day05`](Day05) | SQL query files                                        |
+| [`Day07`](Day07) | Object-oriented PHP classes                            |
+| [`Day09`](Day09) | Browser JavaScript interactions                        |
 
 ## Run PHP Files
 
@@ -55,10 +54,16 @@ sh scripts/check.sh
 
 The script runs `php -l` against every PHP file in the repository.
 
+Related files:
+
+- [`scripts/check.sh`](scripts/check.sh)
+- [`.github/workflows/check.yml`](.github/workflows/check.yml)
+- [`.github/workflows/codeql.yml`](.github/workflows/codeql.yml)
+
 ## Runtime Notes
 
 - No Composer install step is required.
-- Some Day04 flows create local runtime files such as `private/` or `passwd`; those files are ignored.
+- Some [`Day04`](Day04) flows create local runtime files such as `private/` or `passwd`; those files are ignored.
 - Auth examples use intentionally simple file-backed storage and are not production authentication patterns.
 
 ## License


### PR DESCRIPTION
## Summary
- Polish README guidance and badges for archive readiness.
- Keep PHP exercise source unchanged.

## Validation
- `php -v` -> PHP 8.5.4 locally
- `sh scripts/check.sh`
- CI will re-run the repository workflow with its configured PHP version.

## Archive-readiness
- Default branch: `main`
- Remote branch cleanup target after merge: keep only `main`